### PR TITLE
feat: get and filters in purchase orders

### DIFF
--- a/src/pae_compras/api/purchase_orders.py
+++ b/src/pae_compras/api/purchase_orders.py
@@ -1,17 +1,97 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, Query
 from beanie import PydanticObjectId
+from typing import Optional
+from datetime import date
 
 from ..models import (
     PurchaseOrderCreate, 
     PurchaseOrderResponse, 
     MarkShippedResponse,
     CancelOrderRequest,
-    CancelOrderResponse
+    CancelOrderResponse,
+    PurchaseOrderFilters,
+    PaginatedPurchaseOrderResponse,
+    OrderStatus,
 )
 from ..services import purchase_order_service
 from ..services.purchase_order_service import PurchaseOrderService
 
 router = APIRouter()
+
+
+@router.get(
+    "/",
+    response_model=PaginatedPurchaseOrderResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List and filter Purchase Orders",
+    description="Retrieves a paginated list of purchase orders with optional filtering by order number, provider, status, and date ranges.",
+)
+async def list_purchase_orders(
+    order_number: Optional[str] = Query(None, description="Filter by order number (partial match)"),
+    provider_id: Optional[str] = Query(None, description="Filter by provider ID"),
+    status: Optional[OrderStatus] = Query(None, description="Filter by order status"),
+    created_from: Optional[date] = Query(None, description="Filter orders created from this date (YYYY-MM-DD)"),
+    created_to: Optional[date] = Query(None, description="Filter orders created until this date (YYYY-MM-DD)"),
+    delivery_from: Optional[date] = Query(None, description="Filter orders with delivery date from this date (YYYY-MM-DD)"),
+    delivery_to: Optional[date] = Query(None, description="Filter orders with delivery date until this date (YYYY-MM-DD)"),
+    page: int = Query(1, ge=1, description="Page number (starts from 1)"),
+    limit: int = Query(10, ge=1, le=100, description="Number of items per page (max 100)"),
+    service: PurchaseOrderService = Depends(lambda: purchase_order_service),
+) -> PaginatedPurchaseOrderResponse:
+    """
+    Lists purchase orders with filtering and pagination.
+    
+    Supports filtering by:
+    - **order_number**: Partial match on order number
+    - **provider_id**: Exact match on provider ID
+    - **status**: Filter by order status (pending, shipped, completed, cancelled)
+    - **created_from/created_to**: Date range for order creation
+    - **delivery_from/delivery_to**: Date range for required delivery date
+    - **page/limit**: Pagination controls
+    """
+    # Convert provider_id string to PydanticObjectId if provided
+    provider_obj_id = None
+    if provider_id:
+        try:
+            provider_obj_id = PydanticObjectId(provider_id)
+        except Exception:
+            # If invalid ObjectId format, we'll let the service handle it
+            pass
+    
+    filters = PurchaseOrderFilters(
+        order_number=order_number,
+        provider_id=provider_obj_id,
+        status=status,
+        created_from=created_from,
+        created_to=created_to,
+        delivery_from=delivery_from,
+        delivery_to=delivery_to,
+        page=page,
+        limit=limit
+    )
+    
+    return await service.list_purchase_orders(filters)
+
+
+@router.get(
+    "/{order_id}",
+    response_model=PurchaseOrderResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get Purchase Order by ID",
+    description="Retrieves the complete details of a specific purchase order by its ID.",
+)
+async def get_purchase_order(
+    order_id: PydanticObjectId,
+    service: PurchaseOrderService = Depends(lambda: purchase_order_service),
+) -> PurchaseOrderResponse:
+    """
+    Gets a purchase order by its ID.
+    
+    - **order_id**: The ID of the purchase order to retrieve
+    
+    Returns the complete purchase order details including all line items and status information.
+    """
+    return await service.get_purchase_order_by_id(order_id)
 
 
 @router.post(

--- a/src/pae_compras/models/__init__.py
+++ b/src/pae_compras/models/__init__.py
@@ -10,6 +10,9 @@ from .purchase_order import (
     MarkShippedResponse,
     CancelOrderRequest,
     CancelOrderResponse,
+    PurchaseOrderFilters,
+    PaginatedPurchaseOrderResponse,
+    PurchaseOrderSummary,
 )
 from .provider import Provider
 from .product import Product, WeeklyAvailability, LifeTime
@@ -54,6 +57,9 @@ __all__ = [
     "MarkShippedResponse",
     "CancelOrderRequest",
     "CancelOrderResponse",
+    "PurchaseOrderFilters",
+    "PaginatedPurchaseOrderResponse",
+    "PurchaseOrderSummary",
     "Provider",
     "Product",
     "WeeklyAvailability",


### PR DESCRIPTION
feat(api): add endpoints to list, filter, and retrieve purchase orders

- Added GET /api/v1/compras/purchase-orders/ endpoint
  - Supports filtering by order_number, provider_id, status, creation and delivery date ranges
  - Includes pagination with `page` and `limit` parameters
  - Returns a paginated list with full schema (PaginatedPurchaseOrderResponse)

- Added GET /api/v1/compras/purchase-orders/{order_id} endpoint
  - Retrieves detailed info for a single purchase order
  - Returns 404 if not found (PurchaseOrderResponse schema)
